### PR TITLE
feat: compile with PIC

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -15,16 +15,16 @@ def wrapperName := "wrapper"
 def buildDir := defaultBuildDir
 
 def cmarkOTarget (srcName : String) : FileTarget :=
-  let oFile := __dir__ / buildDir / cmarkDir / ⟨ srcName ++ ".o" ⟩ 
+  let oFile := __dir__ / buildDir / cmarkDir / ⟨ srcName ++ ".o" ⟩
   let srcTarget := inputFileTarget <| __dir__ / cmarkDir / ⟨ srcName ++ ".c" ⟩
   fileTargetWithDep oFile srcTarget λ srcFile => do
-    compileO oFile srcFile #["-I", (__dir__ / cmarkDir).toString]
+    compileO oFile srcFile #["-I", (__dir__ / cmarkDir).toString, "-fPIC"]
 
 def wrapperOTarget : FileTarget :=
-  let oFile := __dir__ / buildDir / wrapperDir / ⟨ wrapperName ++ ".o" ⟩ 
+  let oFile := __dir__ / buildDir / wrapperDir / ⟨ wrapperName ++ ".o" ⟩
   let srcTarget := inputFileTarget <| __dir__ / wrapperDir / ⟨ wrapperName ++ ".c" ⟩
   fileTargetWithDep oFile srcTarget λ srcFile => do
-    compileO oFile srcFile #["-I", (← getLeanIncludeDir).toString, "-I", (__dir__ / cmarkDir).toString]
+    compileO oFile srcFile #["-I", (← getLeanIncludeDir).toString, "-I", (__dir__ / cmarkDir).toString, "-fPIC"]
 
 def cmarkTarget : FileTarget :=
   let libFile := __dir__ / buildDir / cmarkDir / "libleancmark.a"


### PR DESCRIPTION
doc-gen on a recent nightly complains about linking issues with the .a file that drops out and
recommends to use `-fPIC`, that fixed it sooooo...let's trust the linker magic!